### PR TITLE
現在時刻を取得するタイムゾーンを東京に固定

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tailwindcss/vite": "^4.0.14",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "luxon": "^3.5.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-scripts": "5.0.1",
@@ -12494,6 +12495,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@tailwindcss/vite": "^4.0.14",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "luxon": "^3.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-scripts": "5.0.1",

--- a/src/CountdownTimer.js
+++ b/src/CountdownTimer.js
@@ -1,18 +1,17 @@
 import React, { useEffect, useState } from "react";
+import { DateTime } from "luxon";
 
 const CountdownTimer = () => {
     const [timeLeft, setTimeLeft] = useState("");
 
     const updateCountdown = () => {
-        const now = new Date();
-        const hoursNow = now.getHours();
+        const now = DateTime.now().setZone("Asia/Tokyo");
+        const hoursNow = now.hour;
 
-        let nextOpenTime = new Date();
-        nextOpenTime.setHours(23, 0, 0, 0);
+        let nextOpenTime = DateTime.now().setZone("Asia/Tokyo").set({ hour: 23, minute: 0, second: 0, millisecond: 0 });
 
         if (hoursNow >= 23) {
-            nextOpenTime.setDate(nextOpenTime.getDate() + 1);
-            nextOpenTime.setHours(8, 0, 0, 0);
+            nextOpenTime = nextOpenTime.plus({ days: 1 }).set({ hour: 8, minute: 0, second: 0, millisecond: 0 });
         }
 
         if (hoursNow >= 23 || hoursNow < 8) {


### PR DESCRIPTION
### 概要
https://github.com/CAT5NEKO/telehoSample/issues/1  
で言及していた内容です。
タイムゾーンを東京に指定することでより正確なテレホタイムの判定にします。  

### 変更点
Date単体の処理からluxonを使ったDate処理へ移行